### PR TITLE
PERF-3185 Extend YCSB to add Queryable Encryption support

### DIFF
--- a/ycsb-mongodb/pom.xml
+++ b/ycsb-mongodb/pom.xml
@@ -45,7 +45,7 @@
   <!-- Properties Management -->
   <properties>
     <maven.assembly.version>2.2.1</maven.assembly.version>
-    <mongodb.version>4.6.0</mongodb.version>
+    <mongodb.version>4.7.0</mongodb.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/ycsb-mongodb/pom.xml
+++ b/ycsb-mongodb/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongodb-crypt</artifactId>
-      <version>1.2.0</version>
+      <version>1.5.2</version>
     </dependency>
     <!-- mongodb-crypt is pulling in a SNAPSHOT release of bson, so to work around that pin the bson library explicitly -->
     <dependency>
@@ -45,7 +45,7 @@
   <!-- Properties Management -->
   <properties>
     <maven.assembly.version>2.2.1</maven.assembly.version>
-    <mongodb.version>4.5.0</mongodb.version>
+    <mongodb.version>4.6.0</mongodb.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 


### PR DESCRIPTION
This patch adds these new properties to the MongoDB YCSB client:
- `mongodb.qe` - boolean flag to enable queryable encryption
- `mongodb.contentionFactors` - string of comma-separated integers that each stands for the QE contention factor of the corresponding encrypted field in the test document. An empty or negative value indicates the default contention factor. (e.g. "4,,5" means contention values of 4, default, and 5 for the 1st, 2nd, and 3rd encrypted fields, respectively)
- `mongodb.cardinalities` - string of comma-separated integers that each stands for the number of unique values that can be uniformly selected for the corresponding field in the test document. An empty or negative value indicates the value can be randomly selected from all possible values. (e.g. 50,,20 means cardinality of 50 and 20 for the first and third fields, and infinite for the rest of the fields). 
- `mongodb.sharded` - boolean flag that indicates whether the target of the workload is a sharded cluster. This is needed for QE-encrypted collections because sharding the collection can only occur after the collection is created.

Here's an evergreen patch test of a QE-enabled YCSB workload: [link](https://spruce.mongodb.com/version/62ec18670305b92793f8b6db/tasks)