### PR TITLE
PERF-4253 - Obfuscate MongoDB password printed to logs by YCSB

### DIFF
--- a/ycsb-mongodb/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/ycsb-mongodb/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -512,7 +512,9 @@ public class MongoDbClient extends DB {
                 db = new MongoDatabase[server.length];
 
                 for (int i=0; i<server.length; i++) {
-                   String url= userPassword.equals("") ? server[i] : server[i].replace("://","://"+userPassword);
+                   String url= server[i].contains("@")
+                            ? server[i]
+                            : userPassword.equals("") ? server[i] : server[i].replace("://","://"+userPassword);
                    if ( i==0 && use_encryption) {
                        AutoEncryptionSettings autoEncryptionSettings = generateEncryptionSettings(url, props);
                        settingsBuilder.autoEncryptionSettings(autoEncryptionSettings);
@@ -526,8 +528,8 @@ public class MongoDbClient extends DB {
 
                        String dispURI = userPassword.equals("")
                                ? url
-                               : url.replace(":" + userPassword, ":XXXXXX");
-                       System.out.println("DEBUG mongo connection created to " + dispURI);
+                               : url.replace(userPassword, username + ":XXXXXX@");
+                       System.out.println("mongo connection created to " + dispURI);
                    } else {
                        settingsBuilder.applyToClusterSettings(builder ->
                                builder.hosts(Collections.singletonList(new ServerAddress(url))));

--- a/ycsb-mongodb/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/ycsb-mongodb/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -403,10 +403,30 @@ public class MongoDbClient extends DB {
             Properties props = getProperties();
             String urls = props.getProperty("mongodb.url", "mongodb://localhost:27017");
 
-            database = props.getProperty("mongodb.database", "ycsb");
             /* Credentials */
+            database = props.getProperty("mongodb.database", "ycsb");
+
+            // Retrieve username and password from properties, set to empty string if they are undefined
             String username = props.getProperty("mongodb.username", "");
             String password = props.getProperty("mongodb.password", "");
+
+            // If the URI contains an @, that means a username and password are specified here as well, so this will parse them out
+            if (urls.contains("@")) {
+                String uriCredentials = urls.substring(urls.indexOf("//") + 2, urls.indexOf("@"));
+                String[] uriCredentialsList = uriCredentials.split(":");
+                String uriUsername = uriCredentialsList[0];
+                String uriPassword = uriCredentialsList[1];
+
+                // If both the URI and properties have credentials defined, check that they are equivalent
+                // If they are not, update credentials to those in the URI and log a warning
+                if (props.keySet().contains("mongodb.username") && props.keySet().contains("mongodb.password")){
+                    if (!uriUsername.equals(username) || !uriPassword.equals(password)){
+                        System.out.println("WARNING: Username/Password provided in the properties does not match what is present in the URI, defaulting to the URI");
+                    }
+                }
+                username = uriUsername;
+                password = uriPassword;
+            }
 
             // Set insert batchsize, default 1 - to be YCSB-original equivalent
             final String batchSizeString = props.getProperty("batchsize", "1");

--- a/ycsb-mongodb/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/ycsb-mongodb/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -532,6 +532,7 @@ public class MongoDbClient extends DB {
                 db = new MongoDatabase[server.length];
 
                 for (int i=0; i<server.length; i++) {
+                   // If the URI does not contain credentials, but they are provided in the properties, append them to the URI
                    String url= server[i].contains("@")
                             ? server[i]
                             : userPassword.equals("") ? server[i] : server[i].replace("://","://"+userPassword);


### PR DESCRIPTION
**JIRA Ticket:** [PERF-4253](https://jira.mongodb.org/browse/PERF-4253)

**Whats Changed:**
Conditional that generates the display URI now first checks if the URI already contains a "@" indicating that it contains user credentials. If yes, the will generate the URI using "XXXXXX" in place of the password. If no "@" is found, the URI is returned as is.

**Patch Results:**
Patch with correct log message can be found [here](https://evergreen.mongodb.com/task_log_raw/sys_perf_linux_standalone.2022_11_industry_benchmarks_patch_fd236101995b46c987960c5170e4835e91078ecb_648ca1377742ae5aeb9ad87b_23_06_16_17_53_29/0?type=T#L2239)
