### PR TITLE
PERF-5725 Add support for snappy and zstd compression

### DIFF
--- a/ycsb-mongodb/mongodb/pom.xml
+++ b/ycsb-mongodb/mongodb/pom.xml
@@ -24,6 +24,9 @@
       <artifactId>core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- mongodb-driver-sync defines snappy-java and zstd-jni dependencies as optional.
+         They need to be repeated here to support compression. See:
+         https://www.mongodb.com/docs/drivers/java/sync/current/fundamentals/connection/network-compression/ -->
     <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>

--- a/ycsb-mongodb/mongodb/pom.xml
+++ b/ycsb-mongodb/mongodb/pom.xml
@@ -24,6 +24,16 @@
       <artifactId>core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>${snappy.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.luben</groupId>
+      <artifactId>zstd-jni</artifactId>
+      <version>${zstd.version}</version>
+    </dependency>
   </dependencies>
  
   <build>

--- a/ycsb-mongodb/pom.xml
+++ b/ycsb-mongodb/pom.xml
@@ -54,6 +54,8 @@
   <properties>
     <maven.assembly.version>2.2.1</maven.assembly.version>
     <mongodb.version>4.7.0</mongodb.version>
+    <snappy.version>1.1.8.4</snappy.version>
+    <zstd.version>1.5.0-4</zstd.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <checkstyle.skip>true</checkstyle.skip>
     <skip.checkstyle>true</skip.checkstyle>

--- a/ycsb-mongodb/pom.xml
+++ b/ycsb-mongodb/pom.xml
@@ -53,6 +53,8 @@
   <!-- Properties Management -->
   <properties>
     <maven.assembly.version>2.2.1</maven.assembly.version>
+    <!-- mongodb, snappy and zstd versions need to be updated together. see:
+         https://www.mongodb.com/docs/drivers/java/sync/current/fundamentals/connection/network-compression/ -->
     <mongodb.version>4.7.0</mongodb.version>
     <snappy.version>1.1.8.4</snappy.version>
     <zstd.version>1.5.0-4</zstd.version>


### PR DESCRIPTION
Add explicit snappy and zstd compressors dependencies. See https://www.mongodb.com/docs/drivers/java/sync/current/fundamentals/connection/network-compression/ for more details. The compressors versions match mongodb driver optional dependencies.

Patch: [here](https://spruce.mongodb.com/version/66ba4589b1185400079cbd8e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)