### PR TITLE
SLS-1922 Prevent endless loop upon shutdown

### DIFF
--- a/ycsb-mongodb/core/src/main/java/site/ycsb/TerminatorThread.java
+++ b/ycsb-mongodb/core/src/main/java/site/ycsb/TerminatorThread.java
@@ -51,10 +51,16 @@ public class TerminatorThread extends Thread {
     System.err.println("Maximum time elapsed. Requesting stop for the workload.");
     workload.requestStop();
     System.err.println("Stop requested for workload. Now Joining!");
+    long startTime = System.currentTimeMillis();
     for (Thread t : threads) {
       while (t.isAlive()) {
         try {
           t.join(waitTimeOutInMS);
+
+          long elapsedTime = System.currentTimeMillis() - startTime;
+          if (elapsedTime > 3 * maxExecutionTime * 1000) {
+            System.exit(1);
+          }
           if (t.isAlive()) {
             System.out.println("Still waiting for thread " + t.getName() + " to complete. " +
                 "Workload status: " + workload.isStopRequested());


### PR DESCRIPTION
In the ds-perf project, sometimes [the YCSB tests get stuck in the shutdown loop](https://evergreen.mongodb.com/task_log_raw/ds_perf_rhel94_arm64_ycsb.load_0128thread.2024_05_cf4549d9de1e865378612d80a7e422ba84595fb2_25_04_15_01_05_57/0?type=T) if the load phase times out. This leads to the task being stuck until it gets timed out by Evergreen, which wastes a lot of resources. 

This PR adds a check that terminates ycsb if the shutdown loop takes> 3 times the configured phase.

Patch that shows the early termination:
https://spruce.mongodb.com/task/ds_perf_rhel94_arm64_ycsb.load_0128thread.2024_05_patch_cf4549d9de1e865378612d80a7e422ba84595fb2_67fe5b7666210300074ed4a4_25_04_15_13_14_53/logs?execution=4&sortBy=STATUS&sortDir=ASC