### PR TITLE
PERF-8161 update HdrHistogram version to fix 'NoClassDefFoundError: javax/xml/bind/DatatypeConverter' error

### DIFF
--- a/ycsb-mongodb/core/pom.xml
+++ b/ycsb-mongodb/core/pom.xml
@@ -58,7 +58,7 @@ LICENSE file.
     <dependency>
       <groupId>org.hdrhistogram</groupId>
       <artifactId>HdrHistogram</artifactId>
-      <version>2.1.4</version>
+      <version>2.1.12</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Update the maven package version to avoid the following exception:
```
2025-09-04T11:27:05Z [info   ] [build/WorkloadOutput/reports/ycsb_load] [TOTAL_GC_TIME_%], Time(%), 1.9266014036028785
2025-09-04T11:27:05Z [info   ] [build/WorkloadOutput/reports/ycsb_load] Exception in thread "main" java.lang.NoClassDefFoundError: javax/xml/bind/DatatypeConverter
2025-09-04T11:27:05Z [info   ] [build/WorkloadOutput/reports/ycsb_load]     at org.HdrHistogram.HistogramLogWriter.outputIntervalHistogram(HistogramLogWriter.java:105)
2025-09-04T11:27:05Z [info   ] [build/WorkloadOutput/reports/ycsb_load]     at org.HdrHistogram.HistogramLogWriter.outputIntervalHistogram(HistogramLogWriter.java:127)
2025-09-04T11:27:05Z [info   ] [build/WorkloadOutput/reports/ycsb_load]     at org.HdrHistogram.HistogramLogWriter.outputIntervalHistogram(HistogramLogWriter.java:147)
2025-09-04T11:27:05Z [info   ] [build/WorkloadOutput/reports/ycsb_load]     at site.ycsb.measurements.OneMeasurementHdrHistogram.exportMeasurements(OneMeasurementHdrHistogram.java:115)
2025-09-04T11:27:05Z [info   ] [build/WorkloadOutput/reports/ycsb_load]     at site.ycsb.measurements.TwoInOneMeasurement.exportMeasurements(TwoInOneMeasurement.java:61)
2025-09-04T11:27:05Z [info   ] [build/WorkloadOutput/reports/ycsb_load]     at site.ycsb.measurements.Measurements.exportMeasurements(Measurements.java:260)
2025-09-04T11:27:05Z [info   ] [build/WorkloadOutput/reports/ycsb_load]     at site.ycsb.Client.exportMeasurements(Client.java:268)
2025-09-04T11:27:05Z [info   ] [build/WorkloadOutput/reports/ycsb_load]     at site.ycsb.Client.main(Client.java:392)
2025-09-04T11:27:05Z [info   ] [build/WorkloadOutput/reports/ycsb_load] Caused by: java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter
2025-09-04T11:27:05Z [info   ] [build/WorkloadOutput/reports/ycsb_load]     ... 8 more
```